### PR TITLE
fix: code snippet highlighting

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -138,6 +138,7 @@ pre {
         border: 0;
         padding-right: 0;
         padding-left: 0;
+        background-color: rgba(0, 0, 0, 0);
     }
 }
 


### PR DESCRIPTION
Currently the snippet highlighting for code looks like this:
http://grab.by/OsmG

My fix changes this to:
http://grab.by/OsmI

I believe the latter was the intended look of the snippets