### PR TITLE
Adding Board Members to About Page

### DIFF
--- a/about.md
+++ b/about.md
@@ -11,6 +11,24 @@ We do that by hanging out on the [Orlando Devs Slack channel]({{ site.baseurl }}
 
 <img src="/assets/bg.jpg" alt="Orlando Devs Meetup" class="img-border">
 
+
+**The Orlando Developers Board Members are as follows,**  
+
+Matt Burgess
+
+Sergio Cruz  
+
+Jacques Fu  
+
+Jorge Hernandez  
+
+Susanna Miller  
+
+Jenell Pizarro  
+
+Cassandra Wilcox
+
+  
 We hope that you will join us soon, be on the Orlando Devs Slack, Orlando Devs Meetup, or all the other software-related meetups happening in Orlando.
 
 Have a blast! 🚀


### PR DESCRIPTION
First iteration of the update, will need to add additional information for the board members before integrating to production.