### PR TITLE
Mobile improvements for homepage buttons.

### DIFF
--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -50,12 +50,12 @@
 
 .oc-welcome .oc-welcome-btns {
   @include media-query($on-palm) {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
 
     .oc-btn {
-      margin: 0 .1rem;
+      padding: .75rem .5rem;
+      margin: .2rem .25em;
       text-align: center;
     }
   }


### PR DESCRIPTION
A possible solution to the mobile display issue with the buttons on the homepage. Looks like a grid works better than a flex.

Also, as the Get On Slack button is so prominently displayed on the top menu. Wouldn't it be better to remove the Join Our Slack button to maintain uniformity?